### PR TITLE
Feature: Account page

### DIFF
--- a/api/node/src/common/util.ts
+++ b/api/node/src/common/util.ts
@@ -1,8 +1,5 @@
 import { strict as assert } from 'assert';
 
-export type Nullable<T> = T | null;
-export type ControllerResponse<T> = Nullable<T> | Error | never;
-
 export function assertMany(...variables: unknown[]): void {
 	variables.forEach((x) => assert(x));
 }

--- a/api/node/src/guard/role.guard.ts
+++ b/api/node/src/guard/role.guard.ts
@@ -14,7 +14,7 @@ export class RolesGuard implements CanActivate {
 
 	canActivate(context: ExecutionContext): boolean {
 		const roles = this.reflector.get<string[]>('roles', context.getHandler());
-		if (!roles) {
+		if (!roles || roles.length === 0) {
 			return true;
 		}
 		const request = context.switchToHttp().getRequest();
@@ -23,6 +23,7 @@ export class RolesGuard implements CanActivate {
 			this.logger.debug('User not found');
 			return false;
 		}
+		this.logger.debug(user, roles);
 		return roles.includes(user.role);
 	}
 }

--- a/api/node/src/service/user/user.entity.ts
+++ b/api/node/src/service/user/user.entity.ts
@@ -1,5 +1,5 @@
 import { Tweet } from '@tweet/tweet.entity';
-import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { CreateUserDTO } from '@type/dto/user';
 
 export enum UserRole {
@@ -33,6 +33,9 @@ export class User {
 
 	@CreateDateColumn()
 	createdAt!: Date;
+
+	@UpdateDateColumn()
+	updatedAt!: Date;
 
 	constructor(props?: CreateUserDTO) {
 		if (props) {

--- a/api/node/src/service/user/user.service.ts
+++ b/api/node/src/service/user/user.service.ts
@@ -2,8 +2,8 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
 import { Repository } from 'typeorm';
-import { CreateUserDTO } from '../../types/dto/user';
-import { User } from './user.entity';
+import { ChangeBasicInformationRequest, CreateUserDTO, GetUserResponse } from '../../types/dto/user';
+import { User, UserRole } from './user.entity';
 import { InternalServerException } from '@type/error/general';
 import { NewsHubLogger } from '@common/logger.service';
 import { UserErrorCodes } from '@type/error/user';
@@ -72,11 +72,30 @@ export class UserService {
 		}
 	}
 
-	async updateEmail(id: string, email: string): Promise<void> {
-		const result = await this.userRepository.update(id, { email });
+	async updateEmail(id: string, payload: ChangeBasicInformationRequest): Promise<void> {
+		const { email, name } = payload;
+		const result = await this.userRepository.update(id, { email, name });
 		if (result.affected === 0) {
 			this.logger.debug(result);
 			throw new InternalServerException();
 		}
+	}
+
+	async updateRole(id: string, role: UserRole): Promise<void> {
+		const result = await this.userRepository.update(id, { role });
+		if (result.affected === 0) {
+			this.logger.debug(result);
+			throw new InternalServerException();
+		}
+	}
+
+	transformUserToUserResponse(user: User): GetUserResponse {
+		const { id, createdAt, email } = user;
+		return {
+			id,
+			createdAt,
+			email,
+			numberOfCollectedTweets: user.tweets.length,
+		};
 	}
 }

--- a/api/node/src/service/user/user.service.ts
+++ b/api/node/src/service/user/user.service.ts
@@ -1,16 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
 import { Repository } from 'typeorm';
 import { CreateUserDTO } from '../../types/dto/user';
 import { User } from './user.entity';
+import { InternalServerException } from '@type/error/general';
+import { NewsHubLogger } from '@common/logger.service';
+import { UserErrorCodes } from '@type/error/user';
 
 @Injectable()
 export class UserService {
 	constructor(
 		@InjectRepository(User)
 		private readonly userRepository: Repository<User>,
-	) {}
+		private readonly logger: NewsHubLogger,
+	) {
+		this.logger.setContext(UserService.name);
+	}
 
 	async findById(id: string): Promise<User | undefined> {
 		return this.userRepository.findOne(id, {
@@ -50,5 +56,27 @@ export class UserService {
 
 	async count(): Promise<number> {
 		return this.userRepository.count();
+	}
+
+	async updatePassword(user: User, oldPassword: string, newPassword: string): Promise<void> {
+		const isPasswordCorrect = await bcrypt.compare(oldPassword, user.password);
+		if (!isPasswordCorrect) {
+			this.logger.debug('Old Password is not correct');
+			throw new BadRequestException(UserErrorCodes.USER_PASSWORD_CHANGE_FAILED);
+		}
+		const hashedPassword = await bcrypt.hash(newPassword, 12);
+		const result = await this.userRepository.update(user.id, { password: hashedPassword });
+		if (result.affected === 0) {
+			this.logger.debug(result);
+			throw new BadRequestException(UserErrorCodes.USER_PASSWORD_CHANGE_FAILED);
+		}
+	}
+
+	async updateEmail(id: string, email: string): Promise<void> {
+		const result = await this.userRepository.update(id, { email });
+		if (result.affected === 0) {
+			this.logger.debug(result);
+			throw new InternalServerException();
+		}
 	}
 }

--- a/api/node/src/types/dto/user.ts
+++ b/api/node/src/types/dto/user.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsEmail, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { IsDate, IsDefined, IsEmail, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString, Min } from 'class-validator';
 import { UserRole } from '@user/user.entity';
 import { TweetResponse } from '@type/dto/tweet';
 
@@ -121,4 +121,28 @@ export class ResetPasswordRequest {
 	@IsString()
 	@IsNotEmpty()
 	newPassword!: string;
+}
+
+export class ChangeBasicInformationRequest {
+	@ApiProperty()
+	@IsString()
+	@IsNotEmpty()
+	name!: string;
+
+	@ApiProperty()
+	@IsString()
+	@IsNotEmpty()
+	email!: string;
+}
+
+export class ChangeUserRoleRequest {
+	@ApiProperty()
+	@IsEnum(UserRole)
+	@IsDefined()
+	role!: UserRole;
+
+	@ApiProperty()
+	@IsString()
+	@IsNotEmpty()
+	userId!: string;
 }

--- a/api/node/src/types/dto/user.ts
+++ b/api/node/src/types/dto/user.ts
@@ -110,3 +110,15 @@ export class UserResponse {
 	@ApiProperty({ type: [TweetResponse] })
 	tweets!: TweetResponse[];
 }
+
+export class ResetPasswordRequest {
+	@ApiProperty()
+	@IsString()
+	@IsNotEmpty()
+	oldPassword!: string;
+
+	@ApiProperty()
+	@IsString()
+	@IsNotEmpty()
+	newPassword!: string;
+}

--- a/api/node/src/types/error/user.ts
+++ b/api/node/src/types/error/user.ts
@@ -1,3 +1,4 @@
 export enum UserErrorCodes {
 	USER_NOT_FOUND = 'User with given id not found',
+	USER_PASSWORD_CHANGE_FAILED = 'User password change failed',
 }

--- a/api/node/src/types/error/user.ts
+++ b/api/node/src/types/error/user.ts
@@ -1,4 +1,5 @@
 export enum UserErrorCodes {
 	USER_NOT_FOUND = 'User with given id not found',
 	USER_PASSWORD_CHANGE_FAILED = 'User password change failed',
+	USER_IS_ADMIN = 'Cant change role of admin user',
 }

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+<html lang='en'>
+<head>
+	<meta charset='UTF-8' />
+	<link href='/src/favicon.svg' rel='icon' type='image/svg+xml' />
+	<meta content='width=device-width, initial-scale=1.0' name='viewport' />
+	<title>NewsHub</title>
+</head>
+<body>
+<div id='root'></div>
+<script src='/src/main.tsx' type='module'></script>
+</body>
 </html>

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -19,6 +19,7 @@
 		"@mantine/notifications": "^4.1.3",
 		"date-fns": "^2.28.0",
 		"dayjs": "^1.11.0",
+		"jwt-decode": "^3.1.2",
 		"react": "^17.0.2",
 		"react-country-flag": "^3.0.2",
 		"react-dom": "^17.0.2",

--- a/apps/dashboard/src/components/BasicInformation.tsx
+++ b/apps/dashboard/src/components/BasicInformation.tsx
@@ -1,0 +1,81 @@
+import AuthContext from '../context/authProvider';
+import { useContext } from 'react';
+import { Button, Container, Group, Paper, Select, TextInput, Title } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { handleFetchErrorResponse } from '../util/handleError';
+import { showNotification } from '@mantine/notifications';
+
+export function BasicInformation() {
+	const { user } = useContext(AuthContext);
+	const form = useForm({
+		initialValues: {
+			username: user?.name,
+			email: user?.email,
+			role: user?.role.toLowerCase(),
+		},
+		validate: {
+			email: (value: string | undefined) => value && (/^\S+@\S+$/.test(value) ? null : 'Invalid email'),
+		},
+	});
+	if (!user) {
+		throw new Error('User is not logged in');
+	}
+
+	const handleSubmit = async (values: typeof form.values) => {
+		const { username, email } = values;
+		const userData = {
+			name: username,
+			email,
+		};
+		const response = await fetch(`${import.meta.env.VITE_API_URL}/user/update/basic-info`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${user.token}`,
+			},
+			body: JSON.stringify(userData),
+		});
+		await handleFetchErrorResponse(response);
+		if (response.ok) {
+			showNotification({
+				message: 'Successfully updated basic information',
+				color: 'green',
+			});
+		}
+	};
+
+	return (
+		<Container size="lg" px={0}>
+			<Title order={2}>Basic Information</Title>
+			<Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+				<form
+					onSubmit={form.onSubmit(async (values) => {
+						await handleSubmit(values);
+					})}
+				>
+					<TextInput required label="Username" {...form.getInputProps('username')} />
+					<TextInput
+						mt="md"
+						required
+						label="Email"
+						autoComplete="username"
+						{...form.getInputProps('email')}
+					/>
+					<Select
+						mt="md"
+						disabled
+						label="Role"
+						data={[
+							{ value: 'user', label: 'USER' },
+							{ value: 'admin', label: 'ADMIN' },
+						]}
+						{...form.getInputProps('role')}
+					/>
+					<Group position="center" mt="md">
+						<Button type="submit">Save</Button>
+					</Group>
+				</form>
+			</Paper>
+		</Container>
+	);
+}

--- a/apps/dashboard/src/components/ChangePassword.tsx
+++ b/apps/dashboard/src/components/ChangePassword.tsx
@@ -1,0 +1,96 @@
+import AuthContext from '../context/authProvider';
+import { useContext } from 'react';
+import { Button, Container, Group, Paper, PasswordInput, Title } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { handleFetchErrorResponse } from '../util/handleError';
+import { showNotification } from '@mantine/notifications';
+
+export function ChangePassword() {
+	const { user } = useContext(AuthContext);
+	const form = useForm({
+		initialValues: {
+			oldPassword: '',
+			newPassword: '',
+			confirmPassword: '',
+		},
+		validate: {
+			oldPassword: (val) => (val.length >= 4 ? null : 'Old password must be at least 4 characters'),
+			newPassword: (val) => (val.length >= 4 ? null : 'Password must be at least 4 characters'),
+			confirmPassword: (val, values) => (val === values!.newPassword ? null : 'Passwords do not match'),
+		},
+	});
+
+	if (!user) {
+		throw new Error('User is not logged in');
+	}
+
+	const handleSubmit = async (values: typeof form.values) => {
+		const { oldPassword, newPassword } = values;
+		const passwordData = {
+			oldPassword,
+			newPassword,
+		};
+		try {
+			const response = await fetch(`${import.meta.env.VITE_API_URL}/user/update/password`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${user.token}`,
+				},
+				body: JSON.stringify(passwordData),
+			});
+			await handleFetchErrorResponse(response);
+			if (response.ok) {
+				showNotification({
+					message: 'Successfully updated password',
+					color: 'green',
+				});
+			}
+		} catch (e) {
+			if (!(e instanceof Error)) {
+				throw e;
+			}
+			showNotification(e);
+		}
+	};
+
+	return (
+		<Container size="lg" px={0} mt="md">
+			<Title order={2}>Password Settings</Title>
+			<Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+				<form
+					onSubmit={form.onSubmit(async (values) => {
+						console.log(values);
+						await handleSubmit(values);
+					})}
+				>
+					<PasswordInput
+						mt="md"
+						required
+						label="Old Password"
+						autoComplete="current-password"
+						{...form.getInputProps('oldPassword')}
+					/>
+					<PasswordInput
+						mt="md"
+						required
+						label="New Password"
+						autoComplete="new-password"
+						{...form.getInputProps('newPassword')}
+					/>
+					<PasswordInput
+						mt="md"
+						required
+						label="Confirm Password"
+						autoComplete="new-password"
+						{...form.getInputProps('confirmPassword')}
+					/>
+
+					<Group position="center" mt="md">
+						<Button type="submit">Save</Button>
+					</Group>
+				</form>
+			</Paper>
+		</Container>
+	);
+}

--- a/apps/dashboard/src/components/NavBar.tsx
+++ b/apps/dashboard/src/components/NavBar.tsx
@@ -66,7 +66,7 @@ export const navbarLinks = [
 	{ link: '/', label: 'Dashboard', icon: LayoutDashboard },
 	{ link: '/tweets', label: 'Tweets', icon: BrandTwitter },
 	{ link: '/parse/tweet', label: 'Parse Tweet', icon: ArrowBigUpLines },
-	{ link: '/user/settings', label: 'Settings', icon: Settings },
+	{ link: '/account', label: 'Settings', icon: Settings },
 ];
 
 export function NavBar() {

--- a/apps/dashboard/src/context/authProvider.tsx
+++ b/apps/dashboard/src/context/authProvider.tsx
@@ -1,18 +1,26 @@
-import { createContext, useState } from 'react';
+import React, { createContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import jwtDecode from 'jwt-decode';
 
 interface AuthProviderProps {
 	children: React.ReactNode;
 }
 
 export interface User {
+	name: string;
+	email: string;
+	role: string;
+	token: string;
+}
+
+export interface LoginResponse {
 	token: string;
 	name: string;
 }
 
 interface AuthContextProps {
 	user: User | undefined;
-	setUser: (user: User | undefined) => void;
+	setUser: (user?: LoginResponse) => void;
 	isLoading: boolean | undefined;
 	setIsLoading: (isLoading: boolean) => void;
 }
@@ -29,14 +37,22 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 	const [user, setUser] = useState<User | undefined>(JSON.parse(localStorage.getItem('user') || 'null'));
 	const [isLoading, setIsLoading] = useState(true);
 
-	const setUserCallback = (user: User | undefined) => {
-		setUser(user);
+	const setUserCallback = (user: LoginResponse | undefined) => {
 		if (!user) {
+			setUser(undefined);
 			localStorage.removeItem('user');
 			navigate('/login');
 			return;
 		}
-		localStorage.setItem('user', JSON.stringify(user));
+		const payload = jwtDecode(user.token) as User;
+		const userPayload = {
+			name: user.name,
+			email: payload.email,
+			role: payload.role,
+			token: user.token,
+		};
+		setUser(userPayload);
+		localStorage.setItem('user', JSON.stringify(userPayload));
 		navigate('/');
 	};
 

--- a/apps/dashboard/src/context/authProvider.tsx
+++ b/apps/dashboard/src/context/authProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface AuthProviderProps {
 	children: React.ReactNode;
@@ -24,10 +25,26 @@ const AuthContext = createContext<AuthContextProps>({
 });
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
+	const navigate = useNavigate();
 	const [user, setUser] = useState<User | undefined>(JSON.parse(localStorage.getItem('user') || 'null'));
 	const [isLoading, setIsLoading] = useState(true);
 
-	return <AuthContext.Provider value={{ user, setUser, isLoading, setIsLoading }}>{children}</AuthContext.Provider>;
+	const setUserCallback = (user: User | undefined) => {
+		setUser(user);
+		if (!user) {
+			localStorage.removeItem('user');
+			navigate('/login');
+			return;
+		}
+		localStorage.setItem('user', JSON.stringify(user));
+		navigate('/');
+	};
+
+	return (
+		<AuthContext.Provider value={{ user, setUser: setUserCallback, isLoading, setIsLoading }}>
+			{children}
+		</AuthContext.Provider>
+	);
 };
 
 export default AuthContext;

--- a/apps/dashboard/src/page/Account.tsx
+++ b/apps/dashboard/src/page/Account.tsx
@@ -1,7 +1,9 @@
-import { Container, createStyles } from '@mantine/core';
+import { Container, createStyles, Title } from '@mantine/core';
 import React, { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AuthContext from '../context/authProvider';
+import { BasicInformation } from '../components/BasicInformation';
+import { ChangePassword } from '../components/ChangePassword';
 
 const useStyles = createStyles((theme) => ({
 	comment: {
@@ -37,9 +39,12 @@ const useStyles = createStyles((theme) => ({
 	backArrow: {
 		textAlign: 'end',
 	},
+	title: {
+		marginBottom: '2%',
+	},
 }));
 
-export function UserSettings() {
+export function Account() {
 	const navigate = useNavigate();
 	const { user, setUser } = useContext(AuthContext);
 	const { classes } = useStyles();
@@ -47,5 +52,14 @@ export function UserSettings() {
 		throw new Error('User is not logged in');
 	}
 
-	return <Container size="lg"></Container>;
+	return (
+		<Container size="lg">
+			<div className={classes.title}>
+				<Title>Account</Title>
+			</div>
+
+			<BasicInformation />
+			<ChangePassword />
+		</Container>
+	);
 }

--- a/apps/dashboard/src/page/Dashboard.tsx
+++ b/apps/dashboard/src/page/Dashboard.tsx
@@ -62,7 +62,7 @@ function getIconByLabel(label: string): keyof typeof icons {
 }
 
 export function Dashboard() {
-	const { user } = useContext(AuthContext);
+	const { user, setUser } = useContext(AuthContext);
 	const { classes } = useStyles();
 	const [stats, setStats] = React.useState<StatCardProps[]>([]);
 
@@ -78,6 +78,10 @@ export function Dashboard() {
 					ContentType: 'application/json',
 				},
 			});
+			if (stats.status === 403) {
+				setUser(undefined);
+				return;
+			}
 			const json = (await stats.json()) as StatsRepoonse[];
 			const newStats = [];
 			for (const stat of json) {
@@ -89,6 +93,7 @@ export function Dashboard() {
 			}
 			setStats(newStats);
 		}
+
 		fetchStats();
 	}, [user]);
 

--- a/apps/dashboard/src/page/LandingPage.tsx
+++ b/apps/dashboard/src/page/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, createStyles, Text, Title, useMantineTheme } from '@mantine/core';
+import { Button, Container, createStyles, Text, Title } from '@mantine/core';
 import React from 'react';
 import { ButtonLink } from '../components/ButtonLink';
 import { Dots } from '../components/Dots';
@@ -88,8 +88,6 @@ const useStyles = createStyles((theme) => ({
 
 export function LandingPage() {
 	const { classes } = useStyles();
-	const theme = useMantineTheme();
-
 	return (
 		<Container className={classes.wrapper} size={1400}>
 			<Dots className={classes.dots} style={{ left: 0, top: 0 }} />

--- a/apps/dashboard/src/page/Login.tsx
+++ b/apps/dashboard/src/page/Login.tsx
@@ -1,12 +1,12 @@
 import { Anchor, Button, Checkbox, Container, Group, Paper, PasswordInput, Text, TextInput } from '@mantine/core';
-import { upperFirst, useForm, useToggle } from '@mantine/hooks';
+import { upperFirst, useToggle } from '@mantine/hooks';
+import { useForm } from '@mantine/form';
 import { showNotification } from '@mantine/notifications';
 import React, { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
-import AuthContext from '../context/authProvider';
+import AuthContext, { LoginResponse } from '../context/authProvider';
 import { handleFetchErrorResponse } from '../util/handleError';
 
-async function login(email: string, password: string) {
+async function login(email: string, password: string): Promise<LoginResponse> {
 	const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/login`, {
 		method: 'POST',
 		headers: {
@@ -22,7 +22,7 @@ async function login(email: string, password: string) {
 	return response.json();
 }
 
-async function register(email: string, password: string, name: string) {
+async function register(email: string, password: string, name: string): Promise<LoginResponse> {
 	const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/register`, {
 		method: 'POST',
 		headers: {
@@ -42,7 +42,6 @@ async function register(email: string, password: string, name: string) {
 export function LoginPage() {
 	const [type, toggle] = useToggle('login', ['login', 'register']);
 	const { setUser } = useContext(AuthContext);
-	const navigate = useNavigate();
 	const form = useForm({
 		initialValues: {
 			email: '',
@@ -51,11 +50,12 @@ export function LoginPage() {
 			confirmPassword: '',
 			terms: true,
 		},
-		validationRules: {
-			email: (val) => /^\S+@\S+$/.test(val),
-			password: (val) => val.length >= 4,
-			terms: (val) => val,
-			confirmPassword: (val, values) => (type === 'register' ? val === values!.password : true),
+		validate: {
+			email: (val) => (/^\S+@\S+$/.test(val) ? null : 'Invalid email'),
+			password: (val) => (val.length >= 4 ? null : 'Password must be at least 4 characters'),
+			terms: (val) => (val === true ? null : 'You must accept the terms and conditions'),
+			confirmPassword: (val, values) =>
+				(type === 'register' ? val === values!.password : true) ? null : 'Passwords do not match',
 		},
 	});
 
@@ -84,30 +84,23 @@ export function LoginPage() {
 				<form onSubmit={form.onSubmit(handleSubmit)}>
 					<Group direction="column" grow>
 						{type === 'register' && (
-							<TextInput
-								label="Name"
-								placeholder="Your name"
-								value={form.values.name}
-								onChange={(event) => form.setFieldValue('name', event.currentTarget.value)}
-							/>
+							<TextInput label="Name" placeholder="Your name" {...form.getInputProps('name')} />
 						)}
 
 						<TextInput
 							required
 							label="Email"
 							placeholder="hello@mantine.dev"
-							value={form.values.email}
-							onChange={(event) => form.setFieldValue('email', event.currentTarget.value)}
-							error={form.errors.email && 'Invalid email'}
+							autoComplete="username"
+							{...form.getInputProps('email')}
 						/>
 
 						<PasswordInput
 							required
 							label="Password"
 							placeholder="Your password"
-							value={form.values.password}
-							onChange={(event) => form.setFieldValue('password', event.currentTarget.value)}
-							error={form.errors.password && 'Password should include at least 4 characters'}
+							autoComplete={type === 'register' ? 'new-password' : 'current-password'}
+							{...form.getInputProps('password')}
 						/>
 
 						{type === 'register' && (
@@ -115,18 +108,13 @@ export function LoginPage() {
 								required
 								label="Confirm password"
 								placeholder="Confirm password"
-								value={form.values.confirmPassword}
-								onChange={(event) => form.setFieldValue('confirmPassword', event.currentTarget.value)}
-								error={form.errors.confirmPassword && 'Passwords did not match'}
+								autoComplete="new-password"
+								{...form.getInputProps('confirmPassword')}
 							/>
 						)}
 
 						{type === 'register' && (
-							<Checkbox
-								label="I accept terms and conditions"
-								checked={form.values.terms}
-								onChange={(event) => form.setFieldValue('terms', event.currentTarget.checked)}
-							/>
+							<Checkbox label="I accept terms and conditions" {...form.getInputProps('terms')} />
 						)}
 					</Group>
 

--- a/apps/dashboard/src/page/Login.tsx
+++ b/apps/dashboard/src/page/Login.tsx
@@ -66,8 +66,6 @@ export function LoginPage() {
 					? await login(values.email, values.password)
 					: await register(values.email, values.password, values.name);
 			setUser(response);
-			localStorage.setItem('user', JSON.stringify(response));
-			navigate('/');
 		} catch (e) {
 			if (!(e instanceof Error)) {
 				throw e;

--- a/apps/dashboard/src/page/ParseTweet.tsx
+++ b/apps/dashboard/src/page/ParseTweet.tsx
@@ -42,9 +42,7 @@ export function ParseTweet() {
 				},
 			});
 			if (response.status === 403) {
-				localStorage.removeItem('user');
 				setUser(undefined);
-				navigate('/home');
 				return;
 			}
 			const data = await response.json();

--- a/apps/dashboard/src/page/TweetDetails.tsx
+++ b/apps/dashboard/src/page/TweetDetails.tsx
@@ -60,7 +60,7 @@ const useStyles = createStyles((theme) => ({
 
 export function TweetDetails() {
 	const navigate = useNavigate();
-	const { user } = useContext(AuthContext);
+	const { user, setUser } = useContext(AuthContext);
 	let { id } = useParams();
 	const [loading, setLoading] = useState(true);
 	const [tweetHTML, setTweetHTML] = useState<string | undefined>(undefined);
@@ -101,6 +101,10 @@ export function TweetDetails() {
 					ContentType: 'application/json',
 				},
 			});
+			if (tweetDetails.status === 403) {
+				setUser(undefined);
+				return;
+			}
 			if (tweetDetails.status !== 200) {
 				const response = await tweetDetails.json();
 				showNotification({

--- a/apps/dashboard/src/page/TweetTable.tsx
+++ b/apps/dashboard/src/page/TweetTable.tsx
@@ -68,9 +68,7 @@ export function TweetTable() {
 			},
 		);
 		if (response.status === 403) {
-			localStorage.removeItem('user');
 			setUser(undefined);
-			navigate('/home');
 			return;
 		}
 		const data = await response.json();

--- a/apps/dashboard/src/page/UserSettings.tsx
+++ b/apps/dashboard/src/page/UserSettings.tsx
@@ -1,16 +1,51 @@
-import { useContext } from 'react';
+import { Container, createStyles } from '@mantine/core';
+import React, { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AuthContext from '../context/authProvider';
+
+const useStyles = createStyles((theme) => ({
+	comment: {
+		padding: `${theme.spacing.lg}px ${theme.spacing.xl}px`,
+	},
+
+	body: {
+		paddingLeft: 54,
+		paddingTop: theme.spacing.sm,
+		fontSize: theme.fontSizes.sm,
+	},
+
+	content: {
+		paddingTop: theme.spacing.lg,
+		'& > p:last-child': {
+			marginBottom: 0,
+		},
+	},
+	icon: {
+		marginRight: 5,
+		color: 'black',
+	},
+	grid: {
+		marginTop: '5%',
+	},
+	divider: {
+		marginTop: '2%',
+		marginBottom: '2%',
+	},
+	table: {
+		textAlign: 'center',
+	},
+	backArrow: {
+		textAlign: 'end',
+	},
+}));
 
 export function UserSettings() {
 	const navigate = useNavigate();
 	const { user, setUser } = useContext(AuthContext);
+	const { classes } = useStyles();
 	if (!user) {
 		throw new Error('User is not logged in');
 	}
-	return (
-		<div>
-			<h1>User Settings</h1>
-		</div>
-	);
+
+	return <Container size="lg"></Container>;
 }

--- a/apps/dashboard/src/routes.tsx
+++ b/apps/dashboard/src/routes.tsx
@@ -8,7 +8,7 @@ import { LoginPage } from './page/Login';
 import { NotFound } from './page/NotFound';
 import { TweetDetails } from './page/TweetDetails';
 import { TweetTable } from './page/TweetTable';
-import { UserSettings } from './page/UserSettings';
+import { Account } from './page/Account';
 import { ParseTweet } from './page/ParseTweet';
 
 export function AppRoutes() {
@@ -22,7 +22,7 @@ export function AppRoutes() {
 				<Route path="tweets" element={<TweetTable />} />
 				<Route path="tweet/:id" element={<TweetDetails />} />
 				<Route path="parse/tweet" element={<ParseTweet />} />
-				<Route path="user/settings" element={<UserSettings />} />
+				<Route path="account" element={<Account />} />
 			</Route>
 			<Route path="*" element={<NotFound />} />
 		</Routes>

--- a/apps/dashboard/yarn.lock
+++ b/apps/dashboard/yarn.lock
@@ -1053,6 +1053,11 @@ json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"


### PR DESCRIPTION
This PR introduces the accounts settings page to the dashboard.  
The user is now able to change his username, email, and password on the dashboard site.  
With this new page, some new routes were also added to the node API:

User routes: 
- `update/password`: Update the password of requesting user
- `update/basic-info`: Update basic info (username, email) of requesting user

Admin routes:
- `change/role`: Update role of passed user